### PR TITLE
Add support for array argument and array options

### DIFF
--- a/Tests/Fixtures/FooBundle/Command/ArrayArgumentCommand.php
+++ b/Tests/Fixtures/FooBundle/Command/ArrayArgumentCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Fixtures\FooBundle\Command;
+
+use Goksagun\SchedulerBundle\Annotation\Schedule;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ArrayArgumentCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('schedule:array-argument')
+            ->setDescription('This command has array argument.')
+            ->addArgument('foo', InputArgument::IS_ARRAY);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $foo = $input->getArgument('foo');
+
+        $output->writeln(implode(' - ', $foo));
+
+        return 0;
+    }
+}

--- a/Tests/Fixtures/FooBundle/Command/ArrayOptionCommand.php
+++ b/Tests/Fixtures/FooBundle/Command/ArrayOptionCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Fixtures\FooBundle\Command;
+
+use Goksagun\SchedulerBundle\Annotation\Schedule;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ArrayOptionCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('schedule:array-option')
+            ->setDescription('This command has array option.')
+            ->addOption('foo', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $foo = $input->getOption('foo');
+
+        $output->writeln(implode(' - ', $foo));
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Implementation of parsing arguments has been changed to use build-in `Process::fromShellCommandline` for async commands and `StringInput` for regular command. This allows passing array arguments and array options to commands, and, as a side effect reduces the size of code.